### PR TITLE
Updated certspotter OS to CentOS 8 Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.0] - 2021-09-09
+
+### Changed
+- From CentOS7 to CentOS8 Stream
+- From Python 2 to Python 3.9
+- Hard coded SQS configuration from within `send_to_mozdef.py` to `sqs_info.txt`
+
+### Fixed
+- Cases where the lock file is left over, maps to no running process, but still prevents new runs from starting
+
+## [3.0.0] - 2019-03-08
+521500e179b7dd0d68a16322c8e7f9cf95d4d867
+### Added
+- Check for lock file to prevent concurrent runs
+- Logrotation
+ 
+### Changed
+- The Watchlist from a comma delimited parameter to a URI pointing to a JSON file
+- The CentOS 7 AMIs to newer versions
+- Userdata to use Sub instead of Join for clarity
+- Awscli version to newer version
+- Log output to go to a log file instead of email
+- CloudFormation templates from JSON to YAML
+
+### Fixed
+- Logging
+
+## [2.1.0] - 2017-01-06
+d3ae4cb2f50dcfca97e39d3313a771164be1657e
+### Added
+- Support for an Elastic IP
+- Support for an S3 hosted watchlist file
+- Add a MozDef event field of only the SAN DNS names which are being watched
+
+## [2.0.0] - 2016-08-12
+6be3679de7360c09306079b1be66474856664733
+### Changed
+- From sending results in email over SES to sending MozDef events over SQS
+
+## [1.0.0] - 2016-08-10
+### Added
+- Initial commit
+
+[Unreleased]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v2.1.0...v3.0.0
+[2.1.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/mozilla/certspotter-cloudformation/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This installation of certspotter will send reports to
 Verbose logs from the past 4 weeks of hourly certspotter runs can be found in
 `/var/log/certspotter.log` and the other weekly logrotated files
 
-## send_to_mozdef.py
+## `send_to_mozdef.py`
 
 This CloudFormation creates a simple python tool called `send_to_mozdef.py`
 which sends certificates discovered by certspotter to MozDef.
 
-### Experimenting with send_to_mozdef.py
+### Experimenting with `send_to_mozdef.py`
 
 To display the message before sending it to MozDef, change the final
 `msg.send()` command to something which prints the message first like this
@@ -26,6 +26,11 @@ To display the message before sending it to MozDef, change the final
     msg.construct()
     print(json.dumps(msg._sendlog))
     msg.send_sqs()
+
+### Testing `send_to_mozdef.py`
+
+The `test_send_to_mozdef.bash` script will set example environment variables
+and run `send_to_mozdef.py`
 
 ## Deploying
 

--- a/certspotter-sqs.yml
+++ b/certspotter-sqs.yml
@@ -1,13 +1,14 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: SSLMate Cert Spotter MozDef monitor
+Description: SSLMate Cert Spotter monitor of the Certificate Transparency logs, emitting events to MozDef
 Metadata:
   SourceCode: https://github.com/mozilla/certspotter-cloudformation
+  Version: 3.1.0
   Todo1: Convert to AWS lambda function
   Todo2: Add heartbeat/watchdog to detect if the cronjob stops working
 Parameters:
   SSHKeyName:
     Description: SSH Key Name
-    Type: String
+    Type: 'AWS::EC2::KeyPair::KeyName'
   SQSRegion:
     Description: The AWS region containing the target SQS queue
     Type: String
@@ -25,9 +26,9 @@ Parameters:
     ConstraintDescription: An s3 URL beginnging with s3://
     AllowedPattern: '^s3://.*'
   CronSchedule:
-    Description: 'The 5 field crontab schedule for running certspotter (Default : Hourly)'
+    Description: 'The 5 field crontab schedule for running certspotter (Default : Every 15 minutes)'
     Type: String
-    Default: '0 * * * *'
+    Default: '*/15 * * * *'
   EIPAllocationId:
     Description: The optional Allocation ID of the already existing Elastic IP you
       want to associate with this new instance
@@ -37,38 +38,46 @@ Conditions:
   AssociateEIP: !Not [ !Equals [ !Ref 'EIPAllocationId', '' ] ]
 Mappings:
   RegionMap:
-    ap-northeast-1:
-      CentOS7x8664EBSHVM: ami-045f38c93733dd48d
-    ap-northeast-2:
-      CentOS7x8664EBSHVM: ami-06cf2a72dadf92410
-    ap-south-1:
-      CentOS7x8664EBSHVM: ami-02e60be79e78fef21
-    ap-southeast-1:
-      CentOS7x8664EBSHVM: ami-0b4dd9d65556cac22
-    ap-southeast-2:
-      CentOS7x8664EBSHVM: ami-08bd00d7713a39e7d
-    ca-central-1:
-      CentOS7x8664EBSHVM: ami-033e6106180a626d0
-    eu-central-1:
-      CentOS7x8664EBSHVM: ami-04cf43aca3e6f3de3
-    eu-north-1:
-      CentOS7x8664EBSHVM: ami-5ee66f20
-    eu-west-1:
-      CentOS7x8664EBSHVM: ami-0ff760d16d9497662
-    eu-west-2:
-      CentOS7x8664EBSHVM: ami-0eab3a90fc693af19
-    eu-west-3:
-      CentOS7x8664EBSHVM: ami-0e1ab783dc9489f34
-    sa-east-1:
-      CentOS7x8664EBSHVM: ami-0b8d86d4bf91850af
-    us-east-1:
-      CentOS7x8664EBSHVM: ami-02eac2c0129f6376b
     us-east-2:
-      CentOS7x8664EBSHVM: ami-0f2b4fc905b0bd1f1
+      CentOS8StreamX8664EBSHVM: ami-045b0a05944af45c1
+    us-east-1:
+      CentOS8StreamX8664EBSHVM: ami-0ee70e88eed976a1b
     us-west-1:
-      CentOS7x8664EBSHVM: ami-074e2d6769f445be5
+      CentOS8StreamX8664EBSHVM: ami-006f59adcb98c236f
     us-west-2:
-      CentOS7x8664EBSHVM: ami-01ed306a12b7d1c96
+      CentOS8StreamX8664EBSHVM: ami-056c679fab9e48d8a
+    af-south-1:
+      CentOS8StreamX8664EBSHVM: ami-01d7c2b5c4fc0218a
+    ap-east-1:
+      CentOS8StreamX8664EBSHVM: ami-0b37ca06a565ba470
+    ap-south-1:
+      CentOS8StreamX8664EBSHVM: ami-0967a8b99f328dfee
+    ap-northeast-1:
+      CentOS8StreamX8664EBSHVM: ami-06ee905d0566e92e7
+    ap-northeast-2:
+      CentOS8StreamX8664EBSHVM: ami-054d85b8af5b91956
+    ap-southeast-1:
+      CentOS8StreamX8664EBSHVM: ami-092422d03e2e1e43f
+    ap-southeast-2:
+      CentOS8StreamX8664EBSHVM: ami-0270da940c59823a1
+    ca-central-1:
+      CentOS8StreamX8664EBSHVM: ami-0c43193f9aa2a22db
+    eu-central-1:
+      CentOS8StreamX8664EBSHVM: ami-071096749fda40d3f
+    eu-west-1:
+      CentOS8StreamX8664EBSHVM: ami-0e0669c0b39d3a79f
+    eu-west-2:
+      CentOS8StreamX8664EBSHVM: ami-0418c980c296f36ce
+    eu-west-3:
+      CentOS8StreamX8664EBSHVM: ami-068ebc10e14d9a504
+    eu-south-1:
+      CentOS8StreamX8664EBSHVM: ami-015495d931a04c6a3
+    eu-north-1:
+      CentOS8StreamX8664EBSHVM: ami-0ab62823bc41fa10a
+    me-south-1:
+      CentOS8StreamX8664EBSHVM: ami-08922e5d0a577ac38
+    sa-east-1:
+      CentOS8StreamX8664EBSHVM: ami-0be416330b68d16f4
 Resources:
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -122,7 +131,7 @@ Resources:
   Instance:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', CentOS7x8664EBSHVM ]
+      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', CentOS8StreamX8664EBSHVM ]
       InstanceType: t2.micro
       Tags:
         - Key: Name
@@ -134,10 +143,10 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -ex
-          for i in {1..3}; do /usr/bin/easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz 2>&1 >> /var/log/initial_user-data.log && break || sleep 10; done
+          for i in {1..3}; do /bin/dnf --assumeyes install python39-pip python39-wheel && /bin/pip3.9 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 >> /var/log/initial_user-data.log && break || sleep 10; done
           install --owner=centos --group=centos --mode=0644 /dev/null /var/log/certspotter.log
           cat << 'EOF' > /etc/cron.d/certspotter
-          ${CronSchedule} centos test -d "/proc/$(test -e /home/centos/.certspotter/lock && cat /home/centos/.certspotter/lock || echo nolock)" || /home/centos/gocode/bin/certspotter -verbose -script /home/centos/send_to_mozdef.py >> /var/log/certspotter.log 2>&1
+          ${CronSchedule} centos test -d "/proc/$(test -e /home/centos/.certspotter/lock && cat /home/centos/.certspotter/lock || echo nolock)" || ( rm --force --verbose /home/centos/.certspotter/lock && echo "$(date) Starting cron initiated run" && /home/centos/gocode/bin/certspotter -verbose -script /home/centos/send_to_mozdef.py && echo "$(date) Finished cron initiated run" ) >> /var/log/certspotter.log 2>&1
           EOF
           cat << 'EOF' > /etc/logrotate.d/certspotter
           /var/log/certspotter.log {
@@ -145,36 +154,36 @@ Resources:
               create 0644 centos centos
           }
           EOF
-          yum --assumeyes install epel-release
-          yum --assumeyes install golang git python-pip jq
-          pip install mozdef_client awscli
+          dnf --assumeyes install epel-release
+          dnf --assumeyes install golang git jq
+          pip3.9 install mozdef_client awscli
           install --owner=centos --group=centos --directory /home/centos/gocode
           install --owner=centos --group=centos --directory /home/centos/.certspotter
           install --owner=centos --group=centos --mode=0644 /dev/null /home/centos/.certspotter/watchlist
-          aws s3 cp --quiet ${WatchListURI} /dev/stdout | jq -r '.domains|map("."+.)|.[]' > /home/centos/.certspotter/watchlist
-          export GOPATH=/home/centos/gocode
-          /usr/bin/go get software.sslmate.com/src/certspotter/cmd/certspotter
+          /usr/local/bin/aws s3 cp --quiet ${WatchListURI} /dev/stdout | jq -r '.domains|map("."+.)|.[]' > /home/centos/.certspotter/watchlist
+          runuser --login centos -c 'GOPATH=/home/centos/gocode /usr/bin/go get software.sslmate.com/src/certspotter/cmd/certspotter'
           install --owner=centos --group=centos --mode=0755 /dev/null /home/centos/send_to_mozdef.py
+          install --owner=centos --group=centos --mode=0644 /dev/null /home/centos/sqs_info.txt
+          echo -n "${SQSRegion},${SQSQueueName},${SQSAccountId}" > /home/centos/sqs_info.txt
           cat << 'EOF' > /home/centos/send_to_mozdef.py
-          #!/usr/bin/env python
+          #!/usr/bin/env python3
           import mozdef_client, os
-          ARGS = ['${SQSRegion}','${SQSQueueName}','${SQSAccountId}']
+          with open('/home/centos/sqs_info.txt') as f:
+              ARGS = [x.strip() for x in f.read().split(',')]
           msg = mozdef_client.MozDefEvent('https://127.0.0.1/this/url/is/not/used')
           msg.summary = 'New certificate detected in Certificate Transparency logs'
           msg.tags = ['tls', 'certificatetransparency']
-          for key in (set(os.environ.data.keys()) &
-                          {'FINGERPRINT', 'LOG_URI','CERT_TYPE', 'ISSUER_DN', 'SERIAL',
-                           'SUBJECT_DN', 'NOT_AFTER_UNIXTIME', 'NOT_BEFORE_UNIXTIME',
-                           'PUBKEY_HASH', 'CERT_PARSEABLE','ENTRY_INDEX'}):
-              msg.details[key.lower().translate(None,'_')] = os.environ.data[key]
-          msg.details['dnsnames'] = [x.strip() for x
-                                      in os.environ.data['DNS_NAMES'].split(',')]
+          for key in (set(os.environ.keys()) &
+                      {'FINGERPRINT', 'LOG_URI','CERT_TYPE', 'ISSUER_DN', 'SERIAL',
+                       'SUBJECT_DN', 'NOT_AFTER_UNIXTIME', 'NOT_BEFORE_UNIXTIME',
+                       'PUBKEY_HASH', 'CERT_PARSEABLE','ENTRY_INDEX'}):
+              msg.details[key.lower().translate({'_': ''})] = os.environ[key]
+          msg.details['dnsnames'] = [x.strip() for x in os.environ['DNS_NAMES'].split(',')]
           with open('/home/centos/.certspotter/watchlist') as f:
               watchlist = f.read().splitlines()
-          msg.details['watched_dnsnames'] = [
-              dnsname for dnsname in msg.details['dnsnames']
+          msg.details['watched_dnsnames'] = [dnsname for dnsname in msg.details['dnsnames']
               if (dnsname in watchlist)
-              or len(
+                 or len(
                   [watchname for watchname in watchlist
                    if watchname[:1] == '.'
                    and (dnsname.endswith(watchname)
@@ -186,7 +195,7 @@ Resources:
           msg.send()
           EOF
           touch /etc/cron.d/certspotter
-          /usr/bin/cfn-signal '${WaitConditionHandle}' 2>&1 >> /var/log/initial_user-data.log
+          /usr/local/bin/cfn-signal '${WaitConditionHandle}' 2>&1 >> /var/log/initial_user-data.log
   WaitConditionHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
   WaitCondition:


### PR DESCRIPTION
### Changed
- From CentOS7 to CentOS8 Stream
- From Python 2 to Python 3.9
- Hard coded SQS configuration from within `send_to_mozdef.py` to `sqs_info.txt`

### Fixed
- Cases where the lock file is left over, maps to no running process, but still prevents new runs from starting

### Added
- CHANGELOG