### PR TITLE
Change event format to Splunk certificate format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2021-11-10
+
+### Changed
+- output from the raw format certspotter provides to a 
+  [Splunk certificate format](https://docs.splunk.com/Documentation/CIM/4.20.2/User/Certificates)
+  which is not a backwards compatible change
+
+### Added
+- log file `certificates_matched.log` recording each matched certificate
+- logic to accommodate a missing SQS queue or DynamoDB
+
 ## [4.0.0] - 2021-11-10
 
 ### Changed
@@ -66,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/mozilla/certspotter-cloudformation/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/mozilla/certspotter-cloudformation/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v2.1.0...v3.0.0

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This [AWS CloudFormation](https://aws.amazon.com/cloudformation/) template,
 [`certspotter-sqs.yml`](certspotter-sqs.yml) will create a hosted version of the 
 [SSLMate certspotter](https://github.com/SSLMate/certspotter) app.
 
-This installation of certspotter will 
+This installation of certspotter will
+* create an events in the [Splunk certificate format](https://docs.splunk.com/Documentation/CIM/4.20.2/User/Certificates)
 * send events to an [AWS Message Queuing Service (SQS)](https://aws.amazon.com/sqs/)
-  queue for every matching certificate. These reports can then be consumed by a SIEM.
+  queue for every matching certificate. These reports can then be consumed by a SIEM (e.g. Splunk).
 * store all matching certificate transparency events in a DynamoDB 
 
 ## Installation
@@ -35,6 +36,8 @@ Verbose logs from the past 4 weeks of certspotter runs can be found in
 start and end of runs can be found with
 
     grep "cron initiated run" /var/log/certspotter.log
+
+A log of every matched certificate is kept in `/home/centos/certificates_matched.log`
 
 ## Files
 

--- a/certspotter-sqs.yml
+++ b/certspotter-sqs.yml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: SSLMate Cert Spotter monitor of the Certificate Transparency logs, emitting events to SQS
 Metadata:
   SourceCode: https://github.com/mozilla/certspotter-cloudformation
-  Version: 4.0.0
+  Version: 5.0.0
   Todo1: Convert to AWS lambda function
   Todo2: Add heartbeat/watchdog to detect if the cronjob stops working
 Parameters:
@@ -198,17 +198,27 @@ Resources:
           fi
           cat << 'EOF' > /home/centos/send_to_sqs.py
           #!/usr/bin/env python3
-          import os, json, boto3
+          import os, json, datetime, boto3
           base_dir = '/home/centos'
           with open(f'{base_dir}/certspotter_config.txt') as f:
               ARGS = [x.strip() for x in f.read().split(',')]
 
           data = {}
-          fields = {
-              'FINGERPRINT', 'LOG_URI','CERT_TYPE', 'ISSUER_DN', 'SERIAL', 'SUBJECT_DN',
-              'NOT_AFTER_UNIXTIME', 'NOT_BEFORE_UNIXTIME', 'PUBKEY_HASH', 'CERT_PARSEABLE','ENTRY_INDEX'}
-          for key in (set(os.environ.keys()) & fields):
-              data[key.lower().translate({'_': ''})] = os.environ[key]
+          field_map = {
+              'FINGERPRINT': 'ssl_hash',
+              'ISSUER_DN': 'ssl_issuer',
+              'SERIAL': 'ssl_serial',
+              'SUBJECT_DN': 'ssl_subject',
+              'NOT_AFTER_UNIXTIME': 'ssl_end_time',
+              'NOT_BEFORE_UNIXTIME': 'ssl_start_time',
+              'LOG_URI': 'log_uri',
+              'CERT_TYPE': 'cert_type',
+              'PUBKEY_HASH': 'pubkey_hash',
+              'CERT_PARSEABLE': 'cert_parseable',
+              'ENTRY_INDEX': 'entry_index',
+          }
+          for key in (set(os.environ.keys()) & field_map.keys()):
+              data[field_map[key]] = os.environ[key]
           data['dnsnames'] = [x.strip() for x in os.environ['DNS_NAMES'].split(',')]
           with open(f'{base_dir}/.certspotter/watchlist') as f:
               watchlist = f.read().splitlines()
@@ -219,18 +229,21 @@ Resources:
 
           data['watched_dnsnames'] = [dnsname for dnsname in data['dnsnames'] if in_watchlist(dnsname, watchlist)]
           data['summary'] = f"New certificate{'s' if len(data['watched_dnsnames']) > 1 else ''} in CT logs for {', '.join(data['watched_dnsnames'])}"
-
-          client = boto3.client('sqs', region_name=ARGS[0])
-          queue_url = client.get_queue_url(QueueName=ARGS[1], QueueOwnerAWSAccountId=ARGS[2])['QueueUrl']
-          client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(data, sort_keys=True))
-          dynamodb = boto3.resource('dynamodb', region_name=ARGS[4])
-          table = dynamodb.Table(ARGS[3])
-          table.load()
-          record_id = f"{data['issuer_dn']}, {data['serial']}"
-          table.put_item(Item={
-              'id': record_id,
-              'date': int(data['not_before_unixtime']),
-              'record': json.dumps(data, sort_keys=True)})
+          record_id = f"{data['ssl_issuer']}, {data['ssl_serial']}"
+          with open(f'{base_dir}/certificates_matched.log', 'a') as f:
+              f.write(f"{datetime.datetime.now()} : {data['summary']} with ID \"{record_id}\"\n")
+          if ARGS[0] and ARGS[1] and ARGS[2]:
+              client = boto3.client('sqs', region_name=ARGS[0])
+              queue_url = client.get_queue_url(QueueName=ARGS[1], QueueOwnerAWSAccountId=ARGS[2])['QueueUrl']
+              client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(data, sort_keys=True))
+          if ARGS[3] and ARGS[4]:
+              dynamodb = boto3.resource('dynamodb', region_name=ARGS[4])
+              table = dynamodb.Table(ARGS[3])
+              table.load()
+              table.put_item(Item={
+                  'id': record_id,
+                  'date': int(data['ssl_start_time']),
+                  'record': json.dumps(data, sort_keys=True)})
           EOF
           touch /etc/cron.d/certspotter
           /usr/local/bin/cfn-signal '${WaitConditionHandle}' 2>&1 >> /var/log/initial_user-data.log

--- a/example_record.json
+++ b/example_record.json
@@ -5,14 +5,14 @@
     "certspottertest.security.allizom.org"
   ],
   "entry_index": "98996781",
-  "fingerprint": "74f31fc5df4d3b62ad2540a4eb2a19511882d802bc8a6cca3fdd7dae812bb5d4",
-  "issuer_dn": "C=US, O=Amazon, OU=Server CA 1B, CN=Amazon",
+  "ssl_hash": "74f31fc5df4d3b62ad2540a4eb2a19511882d802bc8a6cca3fdd7dae812bb5d4",
+  "ssl_issuer": "C=US, O=Amazon, OU=Server CA 1B, CN=Amazon",
   "log_uri": "https://oak.ct.letsencrypt.org/2022/",
-  "not_after_unixtime": "1670716799",
-  "not_before_unixtime": "1636588800",
+  "ssl_end_time": "1670716799",
+  "ssl_start_time": "1636588800",
   "pubkey_hash": "716b422e02f6eab60bd2e4d64c03f7b058b7ff0a081d81d9edf3261db6ff9a2a",
-  "serial": "447c4835c925210471e44277fdb8988",
-  "subject_dn": "CN=certspottertest.security.allizom.org",
+  "ssl_serial": "447c4835c925210471e44277fdb8988",
+  "ssl_subject": "CN=certspottertest.security.allizom.org",
   "summary": "New certificate in CT logs for certspottertest.security.allizom.org",
   "watched_dnsnames": [
     "certspottertest.security.allizom.org"

--- a/test.bash
+++ b/test.bash
@@ -17,17 +17,27 @@ python3 send_to_sqs.py
 
 
 # #!/usr/bin/env python3
-# import os, json, boto3
+# import os, json, datetime, boto3
 # base_dir = '/home/centos'
 # with open(f'{base_dir}/certspotter_config.txt') as f:
 #     ARGS = [x.strip() for x in f.read().split(',')]
 #
 # data = {}
-# fields = {
-#     'FINGERPRINT', 'LOG_URI','CERT_TYPE', 'ISSUER_DN', 'SERIAL', 'SUBJECT_DN',
-#     'NOT_AFTER_UNIXTIME', 'NOT_BEFORE_UNIXTIME', 'PUBKEY_HASH', 'CERT_PARSEABLE','ENTRY_INDEX'}
-# for key in (set(os.environ.keys()) & fields):
-#     data[key.lower().translate({'_': ''})] = os.environ[key]
+# field_map = {
+#     'FINGERPRINT': 'ssl_hash',
+#     'ISSUER_DN': 'ssl_issuer',
+#     'SERIAL': 'ssl_serial',
+#     'SUBJECT_DN': 'ssl_subject',
+#     'NOT_AFTER_UNIXTIME': 'ssl_end_time',
+#     'NOT_BEFORE_UNIXTIME': 'ssl_start_time',
+#     'LOG_URI': 'log_uri',
+#     'CERT_TYPE': 'cert_type',
+#     'PUBKEY_HASH': 'pubkey_hash',
+#     'CERT_PARSEABLE': 'cert_parseable',
+#     'ENTRY_INDEX': 'entry_index',
+# }
+# for key in (set(os.environ.keys()) & field_map.keys()):
+#     data[field_map[key]] = os.environ[key]
 # data['dnsnames'] = [x.strip() for x in os.environ['DNS_NAMES'].split(',')]
 # with open(f'{base_dir}/.certspotter/watchlist') as f:
 #     watchlist = f.read().splitlines()
@@ -38,15 +48,18 @@ python3 send_to_sqs.py
 #
 # data['watched_dnsnames'] = [dnsname for dnsname in data['dnsnames'] if in_watchlist(dnsname, watchlist)]
 # data['summary'] = f"New certificate{'s' if len(data['watched_dnsnames']) > 1 else ''} in CT logs for {', '.join(data['watched_dnsnames'])}"
-#
-# client = boto3.client('sqs', region_name=ARGS[0])
-# queue_url = client.get_queue_url(QueueName=ARGS[1], QueueOwnerAWSAccountId=ARGS[2])['QueueUrl']
-# client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(data, sort_keys=True))
-# dynamodb = boto3.resource('dynamodb', region_name=ARGS[4])
-# table = dynamodb.Table(ARGS[3])
-# table.load()
-# record_id = f"{data['issuer_dn']}, {data['serial']}"
-# table.put_item(Item={
-#     'id': record_id,
-#     'date': int(data['not_before_unixtime']),
-#     'record': json.dumps(data, sort_keys=True)})
+# record_id = f"{data['ssl_issuer']}, {data['ssl_serial']}"
+# with open(f'{base_dir}/certificates_matched.log', 'a') as f:
+#     f.write(f"{datetime.datetime.now()} : {data['summary']} with ID \"{record_id}\"\n")
+# if ARGS[0] and ARGS[1] and ARGS[2]:
+#     client = boto3.client('sqs', region_name=ARGS[0])
+#     queue_url = client.get_queue_url(QueueName=ARGS[1], QueueOwnerAWSAccountId=ARGS[2])['QueueUrl']
+#     client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(data, sort_keys=True))
+# if ARGS[3] and ARGS[4]:
+#     dynamodb = boto3.resource('dynamodb', region_name=ARGS[4])
+#     table = dynamodb.Table(ARGS[3])
+#     table.load()
+#     table.put_item(Item={
+#         'id': record_id,
+#         'date': int(data['ssl_start_time']),
+#         'record': json.dumps(data, sort_keys=True)})


### PR DESCRIPTION
- Update to version 5.0.0 as the event format change to Splunk is not backwards compatible

### Changed
- output from the raw format certspotter provides to a
  [Splunk certificate format](https://docs.splunk.com/Documentation/CIM/4.20.2/User/Certificates)
  which is not a backwards compatible change

### Added
- log file `certificates_matched.log` recording each matched certificate
- logic to accommodate a missing SQS queue or DynamoDB