### PR TITLE
Fix missing handling of malformed cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1] - 2023-08-11
+
+### Fixed
+
+- handling of cases where certspotter encounters a malformed certificate
+
 ## [6.0.0] - 2023-05-04
 
 ### Changed
@@ -94,7 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/mozilla/certspotter-cloudformation/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/mozilla/certspotter-cloudformation/compare/v6.0.1...HEAD
+[6.0.1]: https://github.com/mozilla/certspotter-cloudformation/compare/v6.0.0...v6.0.1
+[6.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v5.0.0...v6.0.0
 [5.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/mozilla/certspotter-cloudformation/compare/v3.0.0...v3.1.0

--- a/certspotter-sqs.yml
+++ b/certspotter-sqs.yml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: SSLMate Cert Spotter monitor of the Certificate Transparency logs, emitting events to SQS
 Metadata:
   SourceCode: https://github.com/mozilla/certspotter-cloudformation
-  Version: 6.0.0
+  Version: 6.0.1
   Todo1: Convert to AWS lambda function
   Todo2: Add heartbeat/watchdog to detect if the cronjob stops working
 Parameters:
@@ -225,6 +225,10 @@ Resources:
           }
           for key in (set(os.environ.keys()) & field_map.keys()):
               data[field_map[key]] = os.environ[key]
+          if 'JSON_FILENAME' not in os.environ:
+              with open(f'{base_dir}/certificates_matched.log', 'a') as f:
+                  f.write(f"{datetime.datetime.now()} : ERROR encountered, missing JSON_FILENAME : {json.dumps(dict(os.environ))}\n")
+              exit(0)
           with open(os.environ['JSON_FILENAME']) as f:
               json_file_data = json.load(f)
           data['dnsnames'] = json_file_data['dns_names']

--- a/example_record.json
+++ b/example_record.json
@@ -1,6 +1,5 @@
 {
   "cert_parseable": "yes",
-  "cert_type": "precert",
   "dnsnames": [
     "certspottertest.security.allizom.org"
   ],

--- a/test.bash
+++ b/test.bash
@@ -4,7 +4,6 @@ export SUBJECT_DN="C=US, ST=California, L=San Francisco, O=SALESFORCE.COM, INC.,
 export DNS_NAMES="akamai-san10.exacttarget.com, image.ml.dot-st.com, image.e.banksa.com.au, image.friends.sanrio.co.jp, image.tmc.bankofamerica.com, image.e.mozilla.org, image.email.truhearing.com, image.mcd.nikon.com, image.s.lovesick.com, image.email.hasbro.com, image.e.debenhams.com, image.mail.nibc.com, image.emailing.santanderpb.es, image.m.harley-davidson.ca, image.e.amfam.com, image.mtbemail.com, image.email.enterprise.com, image.email.sans.org, image.ntt-comstore.com, image.email.randstaddirect.nl, image.n-mail.nissay.co.jp, image.email.decathlon.be, image.email.randstadholding.com, image.e.kickstarter.com, image.email.vakantiediscounter.nl, image.e.plumorganics.com, image.r.haken.rikunabi.com, image.r.townwork.net, image.news.auctionata.com, image.subscribers.sbs.com.au, image.secure.castlighthealth.com, image.email-nationwide.com, image.inspiration.auctionata.com, image.notify.auctionata.com, image.mail.allsports.jp, image.emails.thewarehouse.co.nz, image.email.americanfidelity.com, image.s.boxlunch.com"
 export ENTRY_INDEX="29495169"
 export ISSUER_DN="C=US, O=DigiCert Inc, CN=DigiCert SHA2 Secure Server CA"
-export CERT_TYPE="cert"
 export SERIAL="858cee155d7179ea7b50054e670ab50"
 export FINGERPRINT="05e0d7d3c7ba3254bfc9ec6b51af911fb46deaaebc56449d2a831f401ab50b65"
 export LOG_URI="https://ct.googleapis.com/pilot"
@@ -67,7 +66,7 @@ rm /tmp/example-certspotter-match-file.json
 
 # #!/usr/bin/env python3
 # import os, json, datetime, boto3
-# base_dir = '/home/centos'
+# base_dir = '/home/certspotter'
 # with open(f'{base_dir}/certspotter_config.txt') as f:
 #     ARGS = [x.strip() for x in f.read().split(',')]
 #
@@ -80,14 +79,19 @@ rm /tmp/example-certspotter-match-file.json
 #     'NOT_AFTER_UNIXTIME': 'ssl_end_time',
 #     'NOT_BEFORE_UNIXTIME': 'ssl_start_time',
 #     'LOG_URI': 'log_uri',
-#     'CERT_TYPE': 'cert_type',
 #     'PUBKEY_HASH': 'pubkey_hash',
 #     'CERT_PARSEABLE': 'cert_parseable',
 #     'ENTRY_INDEX': 'entry_index',
 # }
 # for key in (set(os.environ.keys()) & field_map.keys()):
 #     data[field_map[key]] = os.environ[key]
-# data['dnsnames'] = [x.strip() for x in os.environ['DNS_NAMES'].split(',')]
+# if 'JSON_FILENAME' not in os.environ:
+#     with open(f'{base_dir}/certificates_matched.log', 'a') as f:
+#         f.write(f"{datetime.datetime.now()} : ERROR encountered, missing JSON_FILENAME : {json.dumps(dict(os.environ))}\n")
+#     exit(0)
+# with open(os.environ['JSON_FILENAME']) as f:
+#     json_file_data = json.load(f)
+# data['dnsnames'] = json_file_data['dns_names']
 # with open(f'{base_dir}/.certspotter/watchlist') as f:
 #     watchlist = f.read().splitlines()
 #


### PR DESCRIPTION
Fix handling of case where certspotter finds a malformed cert

Previously, certspotter could find a malformed cert and it would not create a JSON_FILENAME file

An example of a case like this would be like this

```
EVENT=malformed_cert
SUMMARY=Unable to Parse Entry 65051339 in https://nessie2024.ct.digicert.com/log/
PARSE_ERROR=precertificate in extra_data does not match TBSCertificate in leaf_input: PublicKey not equal
```

send_to_sqs.py would then throw an exception and this would stop the certspotter service

```
Traceback (most recent call last):
  File "/home/certspotter/send_to_sqs.py", line 23, in <module>
    with open(os.environ['JSON_FILENAME']) as f:
  File "/usr/lib64/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'JSON_FILENAME'
```

This commit changes send_to_sqs.py to instead log an error and exit cleanly

[Click here to see this change specifically](https://github.com/mozilla/certspotter-cloudformation/pull/12/commits/2e190ea2074423b9645fc9545799bafacd676a11)

This PR also
* Update test.bash and example JSON to reflect v0.15.0 certspotter format
* Add missing links to CHANGELOG and add 6.0.1 release